### PR TITLE
Updated lookups syntax for newer generator version

### DIFF
--- a/generator.yml
+++ b/generator.yml
@@ -31,5 +31,5 @@ modules:
     - tcpEstabResets
     - tcpCurrEstab
     lookups:
-    - old_index: ifIndex
-      new_index: ifName
+    - source_indexes: ifIndex
+      lookup: ifName


### PR DESCRIPTION
The syntax for lookups was changed in commit [2d8330e66097b4ab685d49d26035ffddfd90b5ff](https://github.com/prometheus/snmp_exporter/commit/2d8330e66097b4ab685d49d26035ffddfd90b5ff#diff-da551bdcad9cde40f0327d1fd522f0da)